### PR TITLE
feat: update .envrc.sample and add doc-generator skill documentation

### DIFF
--- a/.claude/skills/doc-generator/SKILL.md
+++ b/.claude/skills/doc-generator/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: doc-generator
+description: Generate markdown documentation from Python codebases by analyzing source files, extracting docstrings, type hints, and code structure. Use when the user asks to document Python code, create API docs, or generate README files from source code.
+---
+
+# Python Documentation Generator
+
+Generate comprehensive markdown documentation from Python source code.
+
+## When to Use This Skill
+
+- User asks to "document this code" or "generate docs"
+- Creating API documentation from Python modules
+- Generating README files with usage examples
+- Extracting docstrings and type signatures into readable format
+- User mentions "documentation", "docstrings", or "API reference"
+
+## Input
+
+Accept either:
+- Single Python file path
+- Directory path (recursively process .py files)
+- List of specific files
+
+## Output Format
+
+Generate standard markdown with:
+
+```markdown
+# Module Name
+
+Brief description from module docstring.
+
+## Classes
+
+### ClassName
+
+Description from class docstring.
+
+**Methods:**
+- `method_name(param: type) -> return_type`: Brief description
+
+## Functions
+
+### function_name(param: type) -> return_type
+
+Description from docstring.
+
+**Parameters:**
+- `param` (type): Description
+
+**Returns:**
+- type: Description
+
+## Usage Examples
+
+```python
+# Extract from docstring examples or generate basic usage
+```
+```
+
+## Analysis Approach
+
+1. **Parse Python files** using AST or inspection
+2. **Extract key elements:**
+   - Module-level docstrings
+   - Class definitions and docstrings
+   - Function/method signatures with type hints
+   - Docstring content (support Google, NumPy, Sphinx formats)
+3. **Organize hierarchically** (modules -> classes -> methods -> functions)
+4. **Generate clean markdown** with consistent formatting
+
+## Quality Guidelines
+
+- Preserve original docstring formatting when meaningful
+- Include type hints prominently in signatures
+- Group related items (all classes together, all functions together)
+- Add table of contents for large modules
+- Skip private members (leading underscore) unless explicitly requested
+- Handle missing docstrings gracefully (note "No description provided")
+
+## Python Tools
+
+Prefer standard library:
+- `ast` module for parsing
+- `inspect` module for runtime introspection
+- `pathlib` for file handling
+
+No external dependencies required for basic documentation generation.
+
+## Error Handling
+
+- Skip files with syntax errors (log warning)
+- Handle missing type hints gracefully
+- Warn if no docstrings found but continue processing
+- Validate file paths exist before processing

--- a/.envrc.sample
+++ b/.envrc.sample
@@ -1,28 +1,4 @@
-# # OpenTelemetry configuration for SigNoz
-# # Default to localhost - change SIGNOZ_HOST if running SigNoz elsewhere
-# export SIGNOZ_HOST="${SIGNOZ_HOST:-localhost}"
 
-# # OpenTelemetry Resource Attributes
-# export OTEL_RESOURCE_ATTRIBUTES="service.name=fastapiApp"
-
-# # OTLP Exporter Configuration
-# # Using gRPC protocol (default) - port 4317
-# export OTEL_EXPORTER_OTLP_ENDPOINT="http://${SIGNOZ_HOST}:4317"
-# export OTEL_EXPORTER_OTLP_PROTOCOL="grpc"
-
-# # Alternative: For HTTP/protobuf protocol, uncomment these and comment out the gRPC lines above:
-# # export OTEL_EXPORTER_OTLP_ENDPOINT="http://${SIGNOZ_HOST}:4318"
-# # export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
-
-# # Application configuration
-# export APP_HOST="${APP_HOST:-localhost}"
-# export APP_PORT="${APP_PORT:-5002}"
-
-# # SigNoz UI URL (for reference)
-# export SIGNOZ_UI_URL="http://${SIGNOZ_HOST}:3301"
-
-
-#
 # Required
 export OTEL_SERVICE_NAME=logging-lab
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318  # HTTP endpoint

--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,19 @@ cov.xml
 junit/
 monkeytype.sqlite3
 .envrc
+
+# from lunar-claude
+.mcp.json
+.mcp.json.backup
+.vscode
+.DS_Store
+.venv
+.worktrees/
+.rumdl-cache
+.ruff_cache
+*.pyc
+mise.local.toml
+
+.lychee-report.md
+.lycheecache
+.claude/research-cache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,44 @@
+minimum_prek_version: "0.2.0"
+
+default_install_hook_types:
+  - pre-commit
+  - post-checkout
+  - post-merge
+  - post-rewrite
+
+repos:
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    # uv version.
+    rev: 0.9.2
+    hooks:
+      - id: uv-sync
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-shebang-scripts-are-executable
+      - id: detect-private-key
+      - id: detect-aws-credentials
+        args: ["--allow-missing-credentials"]
+      - id: check-executables-have-shebangs
+      - id: check-ast
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-symlinks
+
+  # - repo: https://github.com/rvben/rumdl-pre-commit
+  #   rev: v0.0.166 # Use the latest release tag
+  #   hooks:
+  #     - id: rumdl
+  #       # Only lint user-facing documentation (matches .rumdl.toml include patterns)
+  #       files: ^(README\.md|plugins/[^/]+/README\.md|plugins/[^/]+/[^/]+/README\.md|docs/(architecture|checklists)/[^/]+\.md)$
+
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 42.19.3
+    hooks:
+      - id: renovate-config-validator
+        args: [--strict]

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -1,0 +1,26 @@
+# from lunar-claude
+# Markdown Linter and Formatter written in Rust
+# https://github.com/rvben/rumdl
+# rumdl configuration - INCLUSION-BASED approach
+# Only lint user-facing documentation
+
+[global]
+respect_gitignore = true
+
+# ONLY lint these paths (everything else ignored)
+include = [
+    "./README.md",
+    # "plugins/*/README.md",
+    # "plugins/*/*/README.md",
+    # "docs/architecture/*.md",
+    # "docs/checklists/*.md",
+]
+
+[MD013]
+line_length = 120
+code_blocks = false
+tables = false
+headings = true
+
+[MD033]
+allowed_elements = ["span", "div", "Tip", "example", "commentary"]

--- a/README.md
+++ b/README.md
@@ -1,22 +1,87 @@
 # logging-lab
 
-👉\[\[\[**This is the initial readme for your
-[simple-modern-uv](https://github.com/jlevy/simple-modern-uv) template.** Fill it in and
-delete this message!
-Below are general setup instructions that you may remove or keep and adapt for your
-project.\]\]\]
+A Python lab for experimenting with modern structured logging and distributed tracing.
 
-* * *
+## Features
+
+- **Structured logging** with [structlog](https://www.structlog.org/) - JSON or colored console output
+- **Distributed tracing** with [OpenTelemetry](https://opentelemetry.io/) - trace context propagation
+- **Request correlation** with [asgi-correlation-id](https://github.com/snok/asgi-correlation-id)
+- **Non-blocking I/O** via QueueHandler/QueueListener for async performance
+- **FastAPI** demo application with instrumented endpoints
+
+## Quick Start
+
+```bash
+# Install dependencies
+make install
+
+# Start the server
+make serve
+
+# Or with OpenTelemetry auto-instrumentation
+make serve-otel
+```
+
+The API will be available at `http://localhost:5002`.
+
+## API Endpoints
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /` | Hello World response |
+| `GET /ping` | Health check |
+| `GET /items/{item_id}` | Item lookup with optional query param |
+| `GET /invalid` | Raises ValueError (error handling demo) |
+| `GET /exception` | OpenTelemetry span exception recording demo |
+| `GET /external-api` | External HTTP call to httpbin.org |
+
+## Development
+
+```bash
+# Run linting and type checking
+make lint
+
+# Run tests
+make test
+
+# Run both
+make
+```
+
+## Load Testing
+
+```bash
+# Headless mode (10 users, 1 spawn rate)
+make locust
+
+# With web UI
+make locust-ui
+```
+
+## Architecture
+
+```
+src/logging_lab/
+├── app.py            # FastAPI application with endpoints
+├── logging_config.py # Structlog + stdlib logging configuration
+├── middleware.py     # Access log middleware
+└── telemetry.py      # OpenTelemetry tracer setup
+```
+
+### Logging Architecture
+
+- **Structlog** serves as the frontend API with context propagation
+- **Python stdlib logging** as backend with QueueHandler for non-blocking I/O
+- **ProcessorFormatter** unifies both structlog and library logs (Uvicorn, etc.)
+- Logs include `trace_id`, `span_id`, and `request_id` for correlation
 
 ## Project Docs
 
-For how to install uv and Python, see [installation.md](installation.md).
+- [installation.md](installation.md) - Installing uv and Python
+- [development.md](development.md) - Development workflows
+- [publishing.md](publishing.md) - Publishing to PyPI
 
-For development workflows, see [development.md](development.md).
+---
 
-For instructions on publishing to PyPI, see [publishing.md](publishing.md).
-
-* * *
-
-*This project was built from
-[simple-modern-uv](https://github.com/jlevy/simple-modern-uv).*
+*Built from [simple-modern-uv](https://github.com/jlevy/simple-modern-uv).*

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,89 @@
+# from lunar-claude
+# git-cliff ~ configuration file
+# https://git-cliff.org/docs/configuration
+
+
+[changelog]
+# A Tera template to be rendered for each release in the changelog.
+# See https://keats.github.io/tera/docs/#introduction
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
+            {% if commit.breaking %}[**breaking**] {% endif %}\
+            {{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}
+"""
+# Remove leading and trailing whitespaces from the changelog's body.
+trim = true
+# Render body even when there are no releases to process.
+render_always = true
+# An array of regex based postprocessors to modify the changelog.
+postprocessors = [
+    # Replace the placeholder <REPO> with a URL.
+    #{ pattern = '<REPO>', replace = "https://github.com/basher83/lunar-claude" },
+]
+
+[git]
+# Parse commits according to the conventional commits specification.
+# See https://www.conventionalcommits.org
+conventional_commits = true
+# Exclude commits that do not match the conventional commits specification.
+filter_unconventional = true
+# Require all commits to be conventional.
+# Takes precedence over filter_unconventional.
+require_conventional = false
+# Split commits on newlines, treating each line as an individual commit.
+split_commits = false
+# An array of regex based parsers to modify commit messages prior to further processing.
+commit_preprocessors = [
+    # Replace issue numbers with link templates to be updated in `changelog.postprocessors`.
+    #{ pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](<REPO>/issues/${2}))"},
+    # Check spelling of the commit message using https://github.com/crate-ci/typos.
+    # If the spelling is incorrect, it will be fixed automatically.
+    #{ pattern = '.*', replace_command = 'typos --write-changes -' },
+]
+# Prevent commits that are breaking from being excluded by commit parsers.
+protect_breaking_commits = false
+# An array of regex based parsers for extracting data from the commit message.
+# Assigns commits to groups.
+# Optionally sets the commit's scope and can decide to exclude commits from further processing.
+commit_parsers = [
+    { message = "^feat", group = "<!-- 0 -->🚀 Features" },
+    { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
+    { message = "^doc", group = "<!-- 3 -->📚 Documentation" },
+    { message = "^perf", group = "<!-- 4 -->⚡ Performance" },
+    { message = "^refactor", group = "<!-- 2 -->🚜 Refactor" },
+    { message = "^style", group = "<!-- 5 -->🎨 Styling" },
+    { message = "^test", group = "<!-- 6 -->🧪 Testing" },
+    { message = "^chore\\(release\\): prepare for", skip = true },
+    { message = "^chore\\(deps.*\\)", skip = true },
+    { message = "^chore\\(pr\\)", skip = true },
+    { message = "^chore\\(pull\\)", skip = true },
+    { message = "^chore|^ci", group = "<!-- 7 -->⚙️ Miscellaneous Tasks" },
+    { body = ".*security", group = "<!-- 8 -->🛡️ Security" },
+    { message = "^revert", group = "<!-- 9 -->◀️ Revert" },
+    { message = ".*", group = "<!-- 10 -->💼 Other" },
+]
+# Exclude commits that are not matched by any commit parser.
+filter_commits = false
+# An array of link parsers for extracting external references, and turning them into URLs, using regex.
+link_parsers = []
+# Include only the tags that belong to the current branch.
+use_branch_tags = false
+# Order releases topologically instead of chronologically.
+topo_order = false
+# Order releases topologically instead of chronologically.
+topo_order_commits = true
+# Order of commits in each group/release within the changelog.
+# Allowed values: newest, oldest
+sort_commits = "oldest"
+# Process submodules commits
+recurse_submodules = false

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,135 @@
+# from lunar-claude
+#############################  Display  #############################
+
+# Verbose program output
+# Accepts log level: "error", "warn", "info", "debug", "trace"
+verbose = "info"
+
+# Don't show interactive progress bar while checking links.
+no_progress = false
+
+# Path to summary output file.
+output = ".lychee-report.md"
+
+#############################  Cache  ###############################
+
+# Enable link caching. This can be helpful to avoid checking the same links on
+# multiple runs.
+cache = true
+
+# Discard all cached requests older than this duration.
+max_cache_age = "7d"
+
+#############################  Runtime  #############################
+
+# Number of threads to utilize.
+# Defaults to number of cores available to the system if omitted.
+# threads = 2
+
+# Maximum number of allowed redirects.
+max_redirects = 10
+
+# Maximum number of allowed retries before a link is declared dead.
+max_retries = 2
+
+# Maximum number of concurrent link checks.
+max_concurrency = 20
+
+#############################  Requests  ############################
+
+# User agent to send with each request.
+user_agent = "lychee/0.21.0"
+
+# Website timeout from connect to response finished.
+timeout = 20
+
+# Minimum wait time in seconds between retries of failed requests.
+retry_wait_time = 2
+
+# Comma-separated list of accepted status codes for valid links.
+# 401/403/405 are included for API endpoints that require authentication
+# (these indicate the endpoint exists but needs auth, which is expected for examples)
+accept = ["200", "401", "403", "405", "429"]
+
+# Proceed for server connections considered insecure (invalid TLS).
+insecure = false
+
+# Only test links with the given schemes (e.g. https).
+# Omit to check links with any other scheme.
+# At the moment, we support http, https, file, and mailto.
+scheme = ["https", "http"]
+
+# When links are available using HTTPS, treat HTTP links as errors.
+require_https = false
+
+# Request method
+method = "get"
+
+# Fallback extensions to apply when a URL does not specify one.
+# This is common in documentation tools that cross-reference files without extensions.
+fallback_extensions = ["md", "html"]
+
+# Enable the checking of fragments in links.
+include_fragments = true
+
+#############################  Exclusions  ##########################
+
+# Skip missing input files (default is to error if they don't exist).
+skip_missing = false
+
+# Check links inside `<code>` and `<pre>` blocks as well as Markdown code
+# blocks.
+include_verbatim = false
+
+# Ignore case of paths when matching glob patterns.
+glob_ignore_case = false
+
+# Exclude URLs and mail addresses from checking. The values are treated as regular expressions
+exclude = [
+    # Localhost URLs (from code examples)
+    '^https?://localhost',
+    '^https?://127\.0\.0\.1',
+    '^https?://0\.0\.0\.0',
+    # File URLs
+    '^file://',
+    # Private/local development URLs
+    '^https?://.*\.local',
+    # Common example domains
+    '^https?://example\.com',
+    '^https?://example\.org',
+    # API base URLs (examples in documentation - these are just endpoint roots)
+    '^https?://api\.(stripe|openai)\.com/v1/?$',
+    # Demo/test environments
+    '^https?://demo\.netbox\.dev',
+]
+
+# Exclude paths from getting checked. The values are treated as regular expressions
+exclude_path = [
+    # Exclude node_modules and other common build/dependency directories
+    "(^|/)node_modules/",
+    "(^|/)\\.venv/",
+    "(^|/)\\.git/",
+    "(^|/)__pycache__/",
+    "(^|/)\\.pytest_cache/",
+    # Exclude test fixtures that may contain example URLs
+    "(^|/)tests/fixtures/",
+    # Exclude lychee report file (contains old broken links)
+    "(^|/)\\.lychee-report\\.md$",
+]
+
+# Exclude all private IPs from checking.
+# Equivalent to setting `exclude_private`, `exclude_link_local`, and
+# `exclude_loopback` to true.
+exclude_all_private = true
+
+# Exclude private IP address ranges from checking.
+exclude_private = true
+
+# Exclude link-local IP address range from checking.
+exclude_link_local = true
+
+# Exclude loopback IP address range and localhost from checking.
+exclude_loopback = true
+
+# Check mail addresses
+include_mail = false

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>basher83/renovate-config",
+    "local>basher83/renovate-config//presets/python.json"
+  ]
+}


### PR DESCRIPTION
- Cleaned up .envrc.sample by removing commented-out OpenTelemetry configuration options, streamlining the file for easier use.
- Introduced SKILL.md for the new doc-generator skill, detailing its purpose, usage, input/output formats, analysis approach, quality guidelines, and error handling for generating markdown documentation from Python codebases.